### PR TITLE
Fix missing comma

### DIFF
--- a/v2.1/intacct_response.v2.1.dtd
+++ b/v2.1/intacct_response.v2.1.dtd
@@ -197,7 +197,7 @@ achbankconfiguration | vendorentityaccount | vendorpref | employeepref | permiss
 <!ELEMENT pricelistitem (recordno,pricelistid,itemid,productlineid?,item_line?,datefrom?,dateto?,qtylimitmin?,qtylimitmax?,value?,valuetype?,fixed?,sale?,status?,currency?)>
 <!ELEMENT vsoeitempricelist (key, pricelistid, itemid, currency, valuebase, percentbase, percentof, status, version, priceentries)>
 <!ELEMENT priceentries (priceentry+)>
-<!ELEMENT priceentry (startdate?, enddate?, value?, markup?, markdown?, bandup?, banddown? memo?)>
+<!ELEMENT priceentry (startdate?, enddate?, value?, markup?, markdown?, bandup?, banddown?, memo?)>
 <!-- For SmartEventLog -->
 <!ELEMENT smarteventlog (recordno?, smartlinkid?, topic?, ownerobject?,timestamp?, userid?, objectkey? ) >
 <!-- For icitemtotals -->


### PR DESCRIPTION
The v2 response DTD has a missing comma and most tooling cannot parse it as a result.
